### PR TITLE
Fix conditionals when inputs are missing

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,60 +1,61 @@
 ---
 # defaults file for purefa
-purefa_url: purefa.com
-purefa_api_token: token
 
-purefa_domain: pure.com
+#purefa_url: purefa.com
+#purefa_api_token: token
 
-purefa_array_name: pure
+#purefa_domain: pure.com
+#purefa_array_name: pure
 
-purefa_phonehome_state: present # present/absent
-# purefa_remote_assist_state: disable # enable/disable
+#purefa_phonehome_state: present # present/absent
+#purefa_remote_assist_state: disable # enable/disable
 
-purefa_ntp_state: absent # present/absent
-purefa_ntp_servers:
-- ntp1.com
+#purefa_ntp_servers:
+#- 0.pool.ntp.org
+#- 1.pool.ntp.org
+#- 2.pool.ntp.org
+#- 3.pool.ntp.org
 
-purefa_dns_state: absent # present/absent
-purefa_dns_servers:
-- "8.8.8.8"
+#purefa_dns_servers:
+#- "8.8.8.8"
+#- "8.8.4.4"
 
-purefa_users:
-- name: pureuser
-  password: pureuser
-  role: array_admin # array_admin/storage_admin/readonly
-  # old_password: old_pass
-  # state: present
+#purefa_users:
+#- name: pureuser
+#  password: pureuser
+#  role: array_admin # array_admin/storage_admin/readonly
+#  state: present # present/absent
 
-purefa_ldap_bind_password: bind_pass
-purefa_ldap:
-  enable: true
-  state: absent # present/absent
-  uri: "ldap://ldap.com"
-  base_dn: "DC=ldap,DC=com"
-  bind_user: "CN=reader,DC=ldap,DC=com"
-  group_base: "OU=groups"
-  aa_group: PureAdmins # array admins
-  sa_group: PureAdmins # storage admins
-  oa_group: PureAdmins # ops admins
-  ro_group: PureAdmins # readonly
+#purefa_ldap_bind_password: bind_pass
+#purefa_ldap:
+#  enable: true
+#  state: absent # present/absent
+#  uri: "ldap://ldap.com"
+#  base_dn: "DC=ldap,DC=com"
+#  bind_user: "CN=reader,DC=ldap,DC=com"
+#  group_base: "OU=groups"
+#  aa_group: PureAdmins # array admins
+#  sa_group: PureAdmins # storage admins
+#  oa_group: PureAdmins # ops admins
+#  ro_group: PureAdmins # readonly
 
-purefa_snmp:
-- name: public
-  community: pws
-  host: 0.0.0.0
-  state: absent
+#purefa_snmp:
+#- name: public
+#  community: pws
+#  host: 0.0.0.0
+#  state: absent
 
-purefa_syslog:
-  state: absent
-  address: syslog.com
-  port: 514
-  protocol: udp # tcp, tls, udp
+#purefa_syslog:
+#  state: absent
+#  address: syslog.com
+#  port: 514
+#  protocol: udp # tcp, tls, udp
 
-purefa_smtp:
-  state: absent # present/absent
-  password: ""
-  user: ""
-  relay_host: mail.com:587
+#purefa_smtp:
+#  state: absent # present/absent
+#  password: ""
+#  user: ""
+#  relay_host: mail.com:587
 
 purefa_alerts:
 - name: "flasharray-alerts@purestorage.com"

--- a/tasks/directory_service.yml
+++ b/tasks/directory_service.yml
@@ -32,8 +32,8 @@
   - name: Manage array admin role 5.2.0 or higher
     purestorage.flasharray.purefa_dsrole:
       role: array_admin
-      group_base: "{{ purefa_ldap.group_base }}"
-      group: "{{ purefa_ldap.aa_group }}"
+      group_base: "{{ purefa_ldap.group_base if purefa_ldap.aa_group is defined else omit }}"
+      group: "{{ purefa_ldap.aa_group | default(omit) }}"
       state: "{{ 'present' if purefa_ldap.aa_group is defined else 'absent' }}"
       fa_url: "{{ purefa_url }}"
       api_token: "{{ purefa_api_token }}"
@@ -41,8 +41,8 @@
   - name: Manage storage admin role 5.2.0 or higher
     purestorage.flasharray.purefa_dsrole:
       role: storage_admin
-      group_base: "{{ purefa_ldap.group_base }}"
-      group: "{{ purefa_ldap.sa_group }}"
+      group_base: "{{ purefa_ldap.group_base if purefa_ldap.sa_group is defined else omit }}"
+      group: "{{ purefa_ldap.sa_group | default(omit) }}"
       state: "{{ 'present' if purefa_ldap.sa_group is defined else 'absent' }}"
       fa_url: "{{ purefa_url }}"
       api_token: "{{ purefa_api_token }}"
@@ -50,8 +50,8 @@
   - name: Manage ops admin role 5.2.0 or higher
     purestorage.flasharray.purefa_dsrole:
       role: ops_admin
-      group_base: "{{ purefa_ldap.group_base }}"
-      group: "{{ purefa_ldap.oa_group }}"
+      group_base: "{{ purefa_ldap.group_base if purefa_ldap.oa_group is defined else omit }}"
+      group: "{{ purefa_ldap.oa_group | default(omit) }}"
       state: "{{ 'present' if purefa_ldap.oa_group is defined else 'absent' }}"
       fa_url: "{{ purefa_url }}"
       api_token: "{{ purefa_api_token }}"
@@ -59,8 +59,8 @@
   - name: Manage readonly role 5.2.0 or higher
     purestorage.flasharray.purefa_dsrole:
       role: readonly
-      group_base: "{{ purefa_ldap.group_base }}"
-      group: "{{ purefa_ldap.ro_group }}"
+      group_base: "{{ purefa_ldap.group_base if purefa_ldap.ro_group is defined else omit }}"
+      group: "{{ purefa_ldap.ro_group | default(omit) }}"
       state: "{{ 'present' if purefa_ldap.ro_group is defined else 'absent' }}"
       fa_url: "{{ purefa_url }}"
       api_token: "{{ purefa_api_token }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,7 @@
     state: "{{ purefa_phonehome_state }}"
     fa_url: "{{ purefa_url }}"
     api_token: "{{ purefa_api_token }}"
+  when: purefa_phonehome_state is defined
   tags:
   - purefa_phonehome
 
@@ -37,20 +38,22 @@
 
 - name: Set NTP server addresses
   purestorage.flasharray.purefa_ntp:
-    state: "{{ purefa_ntp_state | default('present')}}"
+    state: "{{ 'present' if purefa_ntp_servers else 'absent' }}"
     ntp_servers: "{{ purefa_ntp_servers }}"
     fa_url: "{{ purefa_url }}"
     api_token: "{{ purefa_api_token }}"
+  when: purefa_ntp_servers is defined
   tags:
   - purefa_ntp
 
 - name: Set DNS server addresses
   purestorage.flasharray.purefa_dns:
-    state: "{{ purefa_dns_state | default('present')}}"
-    domain: "{{ purefa_domain }}"
+    state: "{{ 'present' if purefa_dns_servers else 'absent' }}"
+    domain: "{{ purefa_domain | default(omit) }}"
     nameservers: "{{ purefa_dns_servers }}"
     fa_url: "{{ purefa_url }}"
     api_token: "{{ purefa_api_token }}"
+  when: purefa_dns_servers is defined
   tags:
   - purefa_dns
 
@@ -64,12 +67,13 @@
     fa_url: "{{ purefa_url }}"
     api_token: "{{ purefa_api_token }}"
   loop: "{{ purefa_users }}"
+  when: purefa_users is defined
   tags:
   - purefa_users
 
 - name: Manage directory service
   include_tasks: directory_service.yml
-  when: purefa_ldap is defined and purefa_ldap_bind_password is defined
+  when: purefa_ldap is defined
   tags:
   - purefa_ldap
 
@@ -83,6 +87,7 @@
     fa_url: "{{ purefa_url }}"
     api_token: "{{ purefa_api_token }}"
   loop: "{{ purefa_snmp }}"
+  when: purefa_snmp is defined
   tags:
   - purefa_snmp
 
@@ -94,18 +99,20 @@
     protocol: "{{ purefa_syslog.protocol }}"
     fa_url: "{{ purefa_url }}"
     api_token: "{{ purefa_api_token }}"
+  when: purefa_syslog is defined
   tags:
   - purefa_syslog
 
 - name: Set SMTP settings
   purestorage.flasharray.purefa_smtp:
-    state: "{{ purefa_smtp.state | default('present')}}"
+    state: "{{ 'present' if purefa_smtp else 'absent' }}"
     sender_domain: "{{ purefa_domain }}"
     password: "{{ purefa_smtp.password }}"
     user: "{{ purefa_smtp.user }}"
     relay_host: "{{ purefa_smtp.relay_host }}"
     fa_url: "{{ purefa_url }}"
     api_token: "{{ purefa_api_token }}"
+  when: purefa_smtp is defined
   tags:
   - purefa_smtp
 


### PR DESCRIPTION
This should take the correct approach to not touch configs when they're not defined and ensure them absent when they're defined to empty.