### PR TITLE
Add support to missing modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,189 @@ ansible-galaxy collection install -r requirements.yaml
 Role Variables
 --------------
 
-A description of the settable variables for this role should go here, including
-any variables that are in defaults/main.yml, vars/main.yml, and any variables
-that can/should be set via parameters to the role. Any variables that are read
-from other roles and/or the global scope (ie. hostvars, group vars, etc.) should
-be mentioned here as well.
+### Array basic config
+There are a few basic configs that can be set in the array:
+
+| Variable | required | type | default | description |
+| -------- | -------- | ---- | ------- | ----------- |
+| purefa_url                  | **Y** | str |  | Array url. |
+| purefa_api_token            | **Y** | str |  | Array api token. |
+| purefa_array_name           | N | str |  | Name of the array. Must conform to correct naming schema. |
+| purefa_phonehome_state      | N | str |  | Define state of phonehome. |
+| purefa_remote_assist_state  | N | str |  | Define state of remote assist. |
+| purefa_ntp_servers          | N | list |  | A list of up to 4 alternate NTP servers. These may include IPv4, IPv6 or FQDNs. Invalid IP addresses will cause the module to fail. No validation is performed for FQDNs. If more than 4 servers are provided, only the first 4 unique nameservers will be used. |
+| purefa_domain               | N | str |  | Domain suffix to be appended when perofrming DNS lookups. |
+| purefa_dns_servers          | N | list |  | List of up to 3 unique DNS server IP addresses. These can be IPv4 or IPv6 - No validation is done of the addresses is performed. |
+
+### Local users
+To manage local user use the variable `purefa_users`
+
+```yml
+purefa_users:
+- name: pureuser
+  password: password
+  state: present
+```
+
+where you can set the following values:
+
+| Variable | required | type | default | description |
+| -------- | -------- | ---- | ------- | ----------- |
+| purefa_users[].name         | **Y** | str |  | The name of the local user account. |
+| purefa_users[].password     | **Y** | str |  | Password for the local user. |
+| purefa_users[].old_password | N | str |  | If changing an existing password, you must provide the old password for security. |
+| purefa_users[].role         | N | str |  | Sets the local user's access level to the array. |
+| purefa_users[].state        | N | str | present | Create, delete or update local user account. |
+
+
+### Directory service
+
+It is possible to configure the array directory service with these variables:
+
+```yml
+purefa_ldap_bind_password: ldap_bind_pass
+purefa_ldap:
+  enable: true
+  uri: "ldap://ldap.example.com"
+  base_dn: "DC=example,DC=com"
+  bind_user: "CN=reader,DC=example,DC=com"
+  group_base: "OU=groups"
+  aa_group: "pureAdmins"
+  sa_group: "storage_admin"
+  oa_group: "ops_admin"
+  ro_group: "readonly"
+```
+
+### SNMP
+Configure SNMP:
+
+```yml
+purefa_snmp:
+- name: public
+  community: pws
+  host: 0.0.0.0
+  state: present
+```
+
+### Syslog
+Configure Syslog:
+
+```yml
+purefa_syslog:
+  state: present
+  address: syslog.example.com
+  port: 1514
+  protocol: udp #tcp, tls, udp
+```
+
+### SMTP
+Configure SMTP:
+
+```yml
+purefa_smtp:
+  state: present
+  user: "user"
+  password: "password"
+  relay_host: mail.example.com:587
+```
+
+### Email alerts
+Configure email alerts:
+
+```yml
+purefa_alerts:
+- name: "flasharray-alerts@purestorage.com"
+  enabled: true
+- name: "email@example.com"
+  enabled: true
+```
+
+### Replication connection
+Manage replication connections between two FlashArrays:
+
+```yml
+purefa_connections:
+- target_url: flasharray01.example.com
+  connection: async
+  target_api: api_token
+```
+
+
+### Volumes
+You can use the variable `purefa_volumegroups` to manage:
+* Volume groups
+* Volumes
+* Protection groups
+    * Replication schedule
+    * Snapshot schedule
+
+This role was created thinking that every volume need to be part of a volume group because of that to create a volume you just need to:
+```
+purefa_volumegroups:
+- name: test-vg
+  volumes:
+  - name: test-vol
+    size: 5G
+  - name: test-vol2
+    size: 10G
+```
+
+You can specify other parameter for `volume groups` and `volumes`:
+
+| Variable | required | type | default | description |
+| -------- | -------- | ---- | ------- | ----------- |
+| purefa_volumegroups[].name      | **Y** | str |  | The name of volume group. |
+| purefa_volumegroups[].eradicate | N     | bool | false | Define whether to eradicate the volume group on delete and leave in trash. |
+| purefa_volumegroups[].state     | N     | str | present | Define whether the volume group should exist or not. |
+| purefa_volumegroups[].bw_qos    | N     | str | present | Bandwidth limit for vgroup in M or G units. M will set MB/s. G will set GB/s. To clear an existing QoS setting use 0 (zero) |
+| purefa_volumegroups[].iops_qos  | N     | str | present | IOPs limit for vgroup - use value or K or M. K will mean 1000. M will mean 1000000. To clear an existing IOPs setting use 0 (zero) |
+| purefa_volumegroups[].volumes   | N     | list |  | list of volumes in that group `{name: str, size: str}` |
+| purefa_volumegroups\[].volumes\[].name      | **Y** | str |  | The name of the volume. |
+| purefa_volumegroups\[].volumes\[].size      | N     | str |  | Volume size in M, G, T or P units. |
+| purefa_volumegroups\[].volumes\[].qos       | N     | str |  | Bandwidth limit for vgroup in M or G units. M will set MB/s. G will set GB/s. To clear an existing QoS setting use 0 (zero) |
+| purefa_volumegroups\[].volumes\[].iops_qos  | N     | str |  | IOPs limit for vgroup - use value or K or M. K will mean 1000. M will mean 1000000. To clear an existing IOPs setting use 0 (zero) |
+| purefa_volumegroups\[].volumes\[].eradicate | N     | bool | false | Define whether to eradicate the volume on delete or leave in trash. |
+| purefa_volumegroups\[].volumes\[].state     | N     | str | present | Define whether the volume should exist or not. |
+
+You can still specify `protection group` setting for each `volume group` for example (to enable replication and snapshot schedule):
+```
+- name: test-vg
+  pg:
+    replication:
+      enabled: true
+    snapshot:
+      enabled: true
+```
+
+All the options are:
+
+
+| Variable | required | type | default | description |
+| -------- | -------- | ---- | ------- | ----------- |
+| purefa_volumegroups[].pg.pgroup    | N | str | volume group name | The name of the protection group. |
+| purefa_volumegroups[].pg.target    | N | list | "{{ pgroup_target }}" | List of remote arrays or offload target for replication protection group to connect to. Note that all replicated protection groups are asynchronous. Target arrays or offload targets must already be connected to the source array. Maximum number of targets per Portection Group is 4, assuming your configuration suppors this. |
+| purefa_volumegroups[].pg.state     | N     | str | present | Define whether the volume group should exist or not. |
+| purefa_volumegroups[].pg.eradicate | N     | bool | false | Define whether to eradicate the protection group on delete and leave in trash. |
+| purefa_volumegroups[].pg.enabled   | N     | bool | true | Define whether to enabled snapshots for the protection group. |
+
+
+### Hosts
+You can use the variable `purefa_hostgroups` to manage host groups and hosts:
+
+```yml
+purefa_hostgroups:
+- name: hostGroup1
+  hosts:
+  - name: hos1
+    iqn: iqn.1993-08.org.debian:01:xxx
+  - name: host2
+    iqn: iqn.1993-08.org.debian:01:xxx
+  connections:
+    flasharray01:
+    - vg_name1/volume1
+    - vg_name1/volume2
+```
+
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -65,3 +65,18 @@ purefa_alerts:
 #- target_url: otherflasharray.purestorage.com
 #  connection: async
 #  target_api: long-uuid-here
+
+#purefa_hostgroups:
+#- name: mygroup
+#  hosts:
+#  - name: myhost1
+#    iqn: iqn.1993-08.org.debian:01:xxxxxxxx
+#  - name: myhost2
+#    nqn: somenqn.com:xxxxxxx
+#    protocol: nvme
+#- name: myothergroup
+#  hosts:
+#  - name: myhost3
+#    wwns:
+#    - wwn-0x5002e10000000000
+#    - wwn-0x500277a4100c4e21

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -80,3 +80,31 @@ purefa_alerts:
 #    wwns:
 #    - wwn-0x5002e10000000000
 #    - wwn-0x500277a4100c4e21
+
+# pgroup_target: flasharray01
+
+# purefa_volumegroups:
+# - name: test-vg
+#   volumes:
+#   - name: test-vol
+#     size: 5G
+#   pg:
+#     pgroup: test-vg
+#     target: "{{ pgroup_target }}"
+#     state: present
+#     eradicate: false
+#     enabled: true
+#     replication:
+#       enabled: true
+#       frequency: 86400
+#       at: 15:30:00
+#       per_day: 5
+#       all_for: 5
+#       blackout_start: 2AM
+#       blackout_end: 5AM
+#     snapshot:
+#       enabled: true
+#       frequency: 86400
+#       at: 15:30:00
+#       per_day: 5
+#       all_for: 5

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,3 +60,8 @@
 purefa_alerts:
 - name: "flasharray-alerts@purestorage.com"
   enabled: true
+
+#purefa_connections:
+#- target_url: otherflasharray.purestorage.com
+#  connection: async
+#  target_api: long-uuid-here

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,4 +1,4 @@
 ---
 collections:
 - name: purestorage.flasharray
-  version: 1.1.8
+  version: 1.1.9

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,4 +1,4 @@
 ---
 collections:
 - name: purestorage.flasharray
-  version: 1.1.7
+  version: 1.1.8

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -141,6 +141,25 @@
   tags:
   - purefa_connections
 
+- name: Manage volume groups
+  purestorage.flasharray.purefa_vg:
+    vgroup: "{{ item.name }}"
+    fa_url: "{{ purefa_url }}"
+    api_token: "{{ purefa_api_token }}"
+  loop: "{{ purefa_volumegroups }}"
+  when: purefa_volumegroups is defined
+  tags:
+  - purefa_volumegroups
+
+- name: Manage volumes
+  purestorage.flasharray.purefa_volume:
+    fa_url: "{{ purefa_url }}"
+    api_token: "{{ purefa_api_token }}"
+  loop: "{{ purefa_volumegroups }}"
+  when: purefa_volumegroups is defined
+  tags:
+  - purefa_volume
+
 - name: Manage hosts
   purestorage.flasharray.purefa_host:
     host: "{{ item.name }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -140,3 +140,34 @@
   when: purefa_connections is defined
   tags:
   - purefa_connections
+
+- name: Manage hosts
+  purestorage.flasharray.purefa_host:
+    host: "{{ item.name }}"
+    lun: "{{ item.lun | default(omit) }}"
+    iqn: "{{ item.iqn | default(omit) }}"   # iscsi: iSCSI
+    nqn: "{{ item.nqn | default(omit) }}"   # nvme: NVMe
+    wwns: "{{ item.wwns | default(omit) }}" # fc: FibreChannel
+    personality: "{{ item.personality | default(omit) }}"
+    preferred_array: "{{ item.preferred_array | default('delete') }}"
+    protocol: "{{ item.protocol | default(omit) }}" # iscsi, nvme, fc or mixed
+    state: "{{ item.state | default ('present') }}"
+    fa_url: "{{ purefa_url }}"
+    api_token: "{{ purefa_api_token }}"
+  loop: "{{ purefa_hostgroups | json_query('[].hosts') | flatten }}"
+  when: purefa_hostgroups is defined
+  tags:
+  - purefa_host
+
+- name: Manage host groups
+  purestorage.flasharray.purefa_hg:
+    host: "{{ item.hosts | json_query('[].name') or omit }}"
+    hostgroup: "{{ item.name }}"
+    state: "{{ item.state | default('present') }}"
+    volume: "{{ item.volumes | default(omit) }}"
+    fa_url: "{{ purefa_url }}"
+    api_token: "{{ purefa_api_token }}"
+  loop: "{{ purefa_hostgroups }}"
+  when: purefa_hostgroups is defined
+  tags:
+  - purefa_hostgroups

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -158,25 +158,25 @@
   loop: "{{ purefa_volumegroups }}"
   when: purefa_volumegroups is defined
   tags:
-  - purefa_volume
+  - purefa_volumes
 
 - name: Manage hosts
   purestorage.flasharray.purefa_host:
-    host: "{{ item.name }}"
-    lun: "{{ item.lun | default(omit) }}"
-    iqn: "{{ item.iqn | default(omit) }}"   # iscsi: iSCSI
-    nqn: "{{ item.nqn | default(omit) }}"   # nvme: NVMe
-    wwns: "{{ item.wwns | default(omit) }}" # fc: FibreChannel
-    personality: "{{ item.personality | default(omit) }}"
-    preferred_array: "{{ item.preferred_array | default('delete') }}"
-    protocol: "{{ item.protocol | default(omit) }}" # iscsi, nvme, fc or mixed
-    state: "{{ item.state | default ('present') }}"
+    host: "{{ item.1.name }}"
+    lun: "{{ item.1.lun | default(omit) }}"
+    iqn: "{{ item.1.iqn | default(omit) }}"   # iscsi: iSCSI
+    nqn: "{{ item.1.nqn | default(omit) }}"   # nvme: NVMe
+    wwns: "{{ item.1.wwns | default(omit) }}" # fc: FibreChannel
+    personality: "{{ item.1.personality | default(omit) }}"
+    preferred_array: "{{ item.1.preferred_array | default('delete') }}"
+    protocol: "{{ item.1.protocol | default(omit) }}" # iscsi, nvme, fc or mixed
+    state: "{{ item.1.state | default ('present') }}"
     fa_url: "{{ purefa_url }}"
     api_token: "{{ purefa_api_token }}"
-  loop: "{{ purefa_hostgroups | json_query('[].hosts') | flatten }}"
+  loop: "{{ purefa_hostgroups | subelements('hosts') }}"
   when: purefa_hostgroups is defined
   tags:
-  - purefa_host
+  - purefa_hosts
 
 - name: Manage host groups
   purestorage.flasharray.purefa_hg:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -202,19 +202,59 @@
 
 - name: Manage protection groups
   purestorage.flasharray.purefa_pg:
-    pgroup: "{{ item.pg_name | default(item.name)  }}"
-    target: "{{ item.pg_target | default(pgroup_target) }}"
+    pgroup: "{{ item.pg.name | default(item.name) }}"
+    target: "{{ item.pg.target | default(pgroup_target) }}"
     # host: "{{ item.host | default(omit) }}" # list
     # hostgroup: "{{ item.hostgroup | default(omit) }}" # list
     volume: "{{ item.volumes | json_query('[].name') | map('regex_replace', '^(.*)$', item.name+'/\\1') | list }}" # list of volumes adding 'volumegroup/' as prefix
-    state: "{{ item.pg_state | default(omit) }}"
-    eradicate: "{{ item.pg_eradicate | default(omit) }}"
-    enabled: "{{ item.pg_enabled | default(omit) }}"
+    state: "{{ item.pg.state | default(omit) }}"
+    eradicate: "{{ item.pg.eradicate | default(omit) }}"
+    enabled: "{{ item.pg.enabled | default(omit) }}"
     fa_url: "{{ purefa_url }}"
     api_token: "{{ purefa_api_token }}"
   loop: "{{ purefa_volumegroups }}"
   when:
   - purefa_volumegroups is defined
-  - item.protection_group is defined and item.protection_group == True
+  - item.pg is defined
+  tags:
+  - purefa_protectiongroups
+
+- name: Update protection group replication schedule
+  purestorage.flasharray.purefa_pgsched:
+    name: "{{ item.pg.name | default(item.name) }}"
+    schedule: replication
+    enabled: "{{ item.pg.replication.enabled }}"
+    replicate_frequency: "{{ item.pg.replication.frequency }}"
+    replicate_at: "{{ item.pg.replication.at }}"
+    target_per_day: "{{ item.pg.replication.per_day }}"
+    target_all_for: "{{ item.pg.replication.all_for }}"
+    blackout_start: "{{ item.pg.replication.blackout_start }}"
+    blackout_end: "{{ item.pg.replication.blackout_end }}"
+    fa_url: "{{ purefa_url }}"
+    api_token: "{{ purefa_api_token }}"
+  loop: "{{ purefa_volumegroups }}"
+  when:
+  - purefa_volumegroups is defined
+  - item.pg is defined
+  - item.pg.replication is defined
+  tags:
+  - purefa_protectiongroups
+
+- name: Update protection group snapshot schedule
+  purestorage.flasharray.purefa_pgsched:
+    name: "{{ item.pg.name | default(item.name) }}"
+    schedule: snapshot
+    enabled: "{{ item.pg.snapshot.enabled }}"
+    snap_frequency: "{{ item.pg.snapshot.frequency }}"
+    snap_at: "{{ item.pg.snapshot.at }}"
+    per_day: "{{ item.pg.snapshot.per_day }}"
+    all_for: "{{ item.pg.snapshot.all_for }}"
+    fa_url: "{{ purefa_url }}"
+    api_token: "{{ purefa_api_token }}"
+  loop: "{{ purefa_volumegroups }}"
+  when:
+  - purefa_volumegroups is defined
+  - item.pg is defined
+  - item.pg.snapshot is defined
   tags:
   - purefa_protectiongroups

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -143,7 +143,9 @@
 
 - name: Manage volume groups
   purestorage.flasharray.purefa_vg:
-    vgroup: "{{ item.name }}"
+    name: "{{ item.name }}"
+    eradicate: "{{ item.eradicate | default(omit) }}"
+    state: "{{ item.state | default(omit) }}"
     fa_url: "{{ purefa_url }}"
     api_token: "{{ purefa_api_token }}"
   loop: "{{ purefa_volumegroups }}"
@@ -153,9 +155,16 @@
 
 - name: Manage volumes
   purestorage.flasharray.purefa_volume:
+    name: "{{ item.0.name }}/{{ item.1.name }}"
+    size: "{{ item.1.size }}"
+    target: "{{ item.1.target | default(omit) }}"
+    overwrite: "{{ item.1.overwrite | default(omit) }}"
+    qos: "{{ item.1.qos | default(omit) }}"
+    eradicate: "{{ item.1.eradicate | default(omit) }}"
+    state: "{{ item.1.state | default(omit) }}"
     fa_url: "{{ purefa_url }}"
     api_token: "{{ purefa_api_token }}"
-  loop: "{{ purefa_volumegroups }}"
+  loop: "{{ purefa_volumegroups | subelements('volumes') }}"
   when: purefa_volumegroups is defined
   tags:
   - purefa_volumes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -144,8 +144,10 @@
 - name: Manage volume groups
   purestorage.flasharray.purefa_vg:
     name: "{{ item.name }}"
-    eradicate: "{{ item.eradicate | default(omit) }}"
-    state: "{{ item.state | default(omit) }}"
+    eradicate: "{{ item.eradicate | default('false') }}"
+    state: "{{ item.state | default('present') }}"
+    bw_qos: "{{ item.bw_qos | default(omit) }}"
+    iops_qos: "{{ item.iops_qos | default(omit) }}"
     fa_url: "{{ purefa_url }}"
     api_token: "{{ purefa_api_token }}"
   loop: "{{ purefa_volumegroups }}"
@@ -156,12 +158,11 @@
 - name: Manage volumes
   purestorage.flasharray.purefa_volume:
     name: "{{ item.0.name }}/{{ item.1.name }}"
-    size: "{{ item.1.size }}"
-    target: "{{ item.1.target | default(omit) }}"
-    overwrite: "{{ item.1.overwrite | default(omit) }}"
+    size: "{{ item.1.size | default(omit) }}"
     qos: "{{ item.1.qos | default(omit) }}"
-    eradicate: "{{ item.1.eradicate | default(omit) }}"
-    state: "{{ item.1.state | default(omit) }}"
+    iops_qos: "{{ item.1.iops_qos | default(omit) }}"
+    eradicate: "{{ item.1.eradicate | default('false') }}"
+    state: "{{ item.1.state | default('present') }}"
     fa_url: "{{ purefa_url }}"
     api_token: "{{ purefa_api_token }}"
   loop: "{{ purefa_volumegroups | subelements('volumes') }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -199,3 +199,22 @@
   when: purefa_hostgroups is defined
   tags:
   - purefa_hostgroups
+
+- name: Manage protection groups
+  purestorage.flasharray.purefa_pg:
+    pgroup: "{{ item.pg_name | default(item.name)  }}"
+    target: "{{ item.pg_target | default(pgroup_target) }}"
+    # host: "{{ item.host | default(omit) }}" # list
+    # hostgroup: "{{ item.hostgroup | default(omit) }}" # list
+    volume: "{{ item.volumes | json_query('[].name') | map('regex_replace', '^(.*)$', item.name+'/\\1') | list }}" # list of volumes adding 'volumegroup/' as prefix
+    state: "{{ item.pg_state | default(omit) }}"
+    eradicate: "{{ item.pg_eradicate | default(omit) }}"
+    enabled: "{{ item.pg_enabled | default(omit) }}"
+    fa_url: "{{ purefa_url }}"
+    api_token: "{{ purefa_api_token }}"
+  loop: "{{ purefa_volumegroups }}"
+  when:
+  - purefa_volumegroups is defined
+  - item.protection_group is defined and item.protection_group == True
+  tags:
+  - purefa_protectiongroups

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -201,60 +201,11 @@
   - purefa_hostgroups
 
 - name: Manage protection groups
-  purestorage.flasharray.purefa_pg:
-    pgroup: "{{ item.pg.name | default(item.name) }}"
-    target: "{{ item.pg.target | default(pgroup_target) }}"
-    # host: "{{ item.host | default(omit) }}" # list
-    # hostgroup: "{{ item.hostgroup | default(omit) }}" # list
-    volume: "{{ item.volumes | json_query('[].name') | map('regex_replace', '^(.*)$', item.name+'/\\1') | list }}" # list of volumes adding 'volumegroup/' as prefix
-    state: "{{ item.pg.state | default(omit) }}"
-    eradicate: "{{ item.pg.eradicate | default(omit) }}"
-    enabled: "{{ item.pg.enabled | default(omit) }}"
-    fa_url: "{{ purefa_url }}"
-    api_token: "{{ purefa_api_token }}"
-  loop: "{{ purefa_volumegroups }}"
+  block:
+    - name: Include tasks to manage protection groups
+      include_tasks: protection_groups.yml
+      loop: "{{ purefa_volumegroups }}"
   when:
   - purefa_volumegroups is defined
-  - item.pg is defined
-  tags:
-  - purefa_protectiongroups
-
-- name: Update protection group replication schedule
-  purestorage.flasharray.purefa_pgsched:
-    name: "{{ item.pg.name | default(item.name) }}"
-    schedule: replication
-    enabled: "{{ item.pg.replication.enabled }}"
-    replicate_frequency: "{{ item.pg.replication.frequency }}"
-    replicate_at: "{{ item.pg.replication.at }}"
-    target_per_day: "{{ item.pg.replication.per_day }}"
-    target_all_for: "{{ item.pg.replication.all_for }}"
-    blackout_start: "{{ item.pg.replication.blackout_start }}"
-    blackout_end: "{{ item.pg.replication.blackout_end }}"
-    fa_url: "{{ purefa_url }}"
-    api_token: "{{ purefa_api_token }}"
-  loop: "{{ purefa_volumegroups }}"
-  when:
-  - purefa_volumegroups is defined
-  - item.pg is defined
-  - item.pg.replication is defined
-  tags:
-  - purefa_protectiongroups
-
-- name: Update protection group snapshot schedule
-  purestorage.flasharray.purefa_pgsched:
-    name: "{{ item.pg.name | default(item.name) }}"
-    schedule: snapshot
-    enabled: "{{ item.pg.snapshot.enabled }}"
-    snap_frequency: "{{ item.pg.snapshot.frequency }}"
-    snap_at: "{{ item.pg.snapshot.at }}"
-    per_day: "{{ item.pg.snapshot.per_day }}"
-    all_for: "{{ item.pg.snapshot.all_for }}"
-    fa_url: "{{ purefa_url }}"
-    api_token: "{{ purefa_api_token }}"
-  loop: "{{ purefa_volumegroups }}"
-  when:
-  - purefa_volumegroups is defined
-  - item.pg is defined
-  - item.pg.snapshot is defined
   tags:
   - purefa_protectiongroups

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -127,3 +127,16 @@
   when: item not in array_info.purefa_info.config.smtp
   tags:
   - purefa_alerts
+
+- name: Manage replication connections
+  purestorage.flasharray.purefa_connect:
+    connection: "{{ item.connection | default('async') }}"
+    target_url: "{{ item.target_url }}"
+    target_api: "{{ item.target_api }}"
+    state: "{{ item.state | default('present') }}"
+    fa_url: "{{ purefa_url }}"
+    api_token: "{{ purefa_api_token }}"
+  loop: "{{ purefa_connections }}"
+  when: purefa_connections is defined
+  tags:
+  - purefa_connections

--- a/tasks/protection_groups.yml
+++ b/tasks/protection_groups.yml
@@ -2,44 +2,42 @@
   purestorage.flasharray.purefa_pg:
     pgroup: "{{ item.pg.name | default(item.name) }}"
     target: "{{ item.pg.target | default(pgroup_target) }}"
-    # host: "{{ item.host | default(omit) }}" # list
-    # hostgroup: "{{ item.hostgroup | default(omit) }}" # list
     volume: "{{ item.volumes | json_query('[].name') | map('regex_replace', '^(.*)$', item.name+'/\\1') | list }}" # list of volumes adding 'volumegroup/' as prefix
-    state: "{{ item.pg.state | default(omit) }}"
-    eradicate: "{{ item.pg.eradicate | default(omit) }}"
-    enabled: "{{ item.pg.enabled | default(omit) }}"
+    state: "{{ item.pg.state | default('present') }}"
+    eradicate: "{{ item.pg.eradicate | default('false') }}"
+    enabled: "{{ item.pg.enabled | default('true') }}"
     fa_url: "{{ purefa_url }}"
     api_token: "{{ purefa_api_token }}"
   when: item.pg is defined
 
-- name: Update protection group replication schedule
-  purestorage.flasharray.purefa_pgsched:
-    name: "{{ item.pg.name | default(item.name) }}"
-    schedule: replication
-    enabled: "{{ item.pg.replication.enabled }}"
-    replicate_frequency: "{{ item.pg.replication.frequency }}"
-    replicate_at: "{{ item.pg.replication.at }}"
-    target_per_day: "{{ item.pg.replication.per_day }}"
-    target_all_for: "{{ item.pg.replication.all_for }}"
-    blackout_start: "{{ item.pg.replication.blackout_start }}"
-    blackout_end: "{{ item.pg.replication.blackout_end }}"
-    fa_url: "{{ purefa_url }}"
-    api_token: "{{ purefa_api_token }}"
-  when:
-  - item.pg is defined
-  - item.pg.replication is defined
+# - name: Update protection group replication schedule
+#   purestorage.flasharray.purefa_pgsched:
+#     name: "{{ item.pg.name | default(item.name) }}"
+#     schedule: replication
+#     enabled: "{{ item.pg.replication.enabled }}"
+#     replicate_frequency: "{{ item.pg.replication.frequency }}"
+#     replicate_at: "{{ item.pg.replication.at }}"
+#     target_per_day: "{{ item.pg.replication.per_day }}"
+#     target_all_for: "{{ item.pg.replication.all_for }}"
+#     blackout_start: "{{ item.pg.replication.blackout_start }}"
+#     blackout_end: "{{ item.pg.replication.blackout_end }}"
+#     fa_url: "{{ purefa_url }}"
+#     api_token: "{{ purefa_api_token }}"
+#   when:
+#   - item.pg is defined
+#   - item.pg.replication is defined
 
-- name: Update protection group snapshot schedule
-  purestorage.flasharray.purefa_pgsched:
-    name: "{{ item.pg.name | default(item.name) }}"
-    schedule: snapshot
-    enabled: "{{ item.pg.snapshot.enabled }}"
-    snap_frequency: "{{ item.pg.snapshot.frequency }}"
-    snap_at: "{{ item.pg.snapshot.at }}"
-    per_day: "{{ item.pg.snapshot.per_day }}"
-    all_for: "{{ item.pg.snapshot.all_for }}"
-    fa_url: "{{ purefa_url }}"
-    api_token: "{{ purefa_api_token }}"
-  when:
-  - item.pg is defined
-  - item.pg.snapshot is defined
+# - name: Update protection group snapshot schedule
+#   purestorage.flasharray.purefa_pgsched:
+#     name: "{{ item.pg.name | default(item.name) }}"
+#     schedule: snapshot
+#     enabled: "{{ item.pg.snapshot.enabled }}"
+#     snap_frequency: "{{ item.pg.snapshot.frequency }}"
+#     snap_at: "{{ item.pg.snapshot.at }}"
+#     per_day: "{{ item.pg.snapshot.per_day }}"
+#     all_for: "{{ item.pg.snapshot.all_for }}"
+#     fa_url: "{{ purefa_url }}"
+#     api_token: "{{ purefa_api_token }}"
+#   when:
+#   - item.pg is defined
+#   - item.pg.snapshot is defined

--- a/tasks/protection_groups.yml
+++ b/tasks/protection_groups.yml
@@ -1,0 +1,45 @@
+- name: Manage protection groups
+  purestorage.flasharray.purefa_pg:
+    pgroup: "{{ item.pg.name | default(item.name) }}"
+    target: "{{ item.pg.target | default(pgroup_target) }}"
+    # host: "{{ item.host | default(omit) }}" # list
+    # hostgroup: "{{ item.hostgroup | default(omit) }}" # list
+    volume: "{{ item.volumes | json_query('[].name') | map('regex_replace', '^(.*)$', item.name+'/\\1') | list }}" # list of volumes adding 'volumegroup/' as prefix
+    state: "{{ item.pg.state | default(omit) }}"
+    eradicate: "{{ item.pg.eradicate | default(omit) }}"
+    enabled: "{{ item.pg.enabled | default(omit) }}"
+    fa_url: "{{ purefa_url }}"
+    api_token: "{{ purefa_api_token }}"
+  when: item.pg is defined
+
+- name: Update protection group replication schedule
+  purestorage.flasharray.purefa_pgsched:
+    name: "{{ item.pg.name | default(item.name) }}"
+    schedule: replication
+    enabled: "{{ item.pg.replication.enabled }}"
+    replicate_frequency: "{{ item.pg.replication.frequency }}"
+    replicate_at: "{{ item.pg.replication.at }}"
+    target_per_day: "{{ item.pg.replication.per_day }}"
+    target_all_for: "{{ item.pg.replication.all_for }}"
+    blackout_start: "{{ item.pg.replication.blackout_start }}"
+    blackout_end: "{{ item.pg.replication.blackout_end }}"
+    fa_url: "{{ purefa_url }}"
+    api_token: "{{ purefa_api_token }}"
+  when:
+  - item.pg is defined
+  - item.pg.replication is defined
+
+- name: Update protection group snapshot schedule
+  purestorage.flasharray.purefa_pgsched:
+    name: "{{ item.pg.name | default(item.name) }}"
+    schedule: snapshot
+    enabled: "{{ item.pg.snapshot.enabled }}"
+    snap_frequency: "{{ item.pg.snapshot.frequency }}"
+    snap_at: "{{ item.pg.snapshot.at }}"
+    per_day: "{{ item.pg.snapshot.per_day }}"
+    all_for: "{{ item.pg.snapshot.all_for }}"
+    fa_url: "{{ purefa_url }}"
+    api_token: "{{ purefa_api_token }}"
+  when:
+  - item.pg is defined
+  - item.pg.snapshot is defined

--- a/tasks/protection_groups.yml
+++ b/tasks/protection_groups.yml
@@ -10,34 +10,38 @@
     api_token: "{{ purefa_api_token }}"
   when: item.pg is defined
 
-# - name: Update protection group replication schedule
-#   purestorage.flasharray.purefa_pgsched:
-#     name: "{{ item.pg.name | default(item.name) }}"
-#     schedule: replication
-#     enabled: "{{ item.pg.replication.enabled }}"
-#     replicate_frequency: "{{ item.pg.replication.frequency }}"
-#     replicate_at: "{{ item.pg.replication.at }}"
-#     target_per_day: "{{ item.pg.replication.per_day }}"
-#     target_all_for: "{{ item.pg.replication.all_for }}"
-#     blackout_start: "{{ item.pg.replication.blackout_start }}"
-#     blackout_end: "{{ item.pg.replication.blackout_end }}"
-#     fa_url: "{{ purefa_url }}"
-#     api_token: "{{ purefa_api_token }}"
-#   when:
-#   - item.pg is defined
-#   - item.pg.replication is defined
+- name: Update protection group replication schedule
+  purestorage.flasharray.purefa_pgsched:
+    name: "{{ item.pg.name | default(item.name) }}"
+    schedule: replication
+    enabled: "{{ item.pg.replication.enabled | default('true')}}"
+    state: "{{ item.pg.replication.state | default('present')}}"
+    replicate_frequency: "{{ item.pg.replication.frequency | default('3600') }}" # 1h
+    replicate_at: "{{ item.pg.replication.at | default(omit) }}"
+    target_per_day: "{{ item.pg.replication.per_day | default('1') }}" # 1day
+    target_days: "{{ item.pg.replication.for_days | default('7') }}" # 7days
+    target_all_for: "{{ item.pg.replication.retain_for | default('86400') }}" # 1day
+    blackout_start: "{{ item.pg.replication.blackout_start | default(omit) }}"
+    blackout_end: "{{ item.pg.replication.blackout_end | default(omit) }}"
+    fa_url: "{{ purefa_url }}"
+    api_token: "{{ purefa_api_token }}"
+  when:
+  - item.pg is defined
+  - item.pg.replication is defined
 
-# - name: Update protection group snapshot schedule
-#   purestorage.flasharray.purefa_pgsched:
-#     name: "{{ item.pg.name | default(item.name) }}"
-#     schedule: snapshot
-#     enabled: "{{ item.pg.snapshot.enabled }}"
-#     snap_frequency: "{{ item.pg.snapshot.frequency }}"
-#     snap_at: "{{ item.pg.snapshot.at }}"
-#     per_day: "{{ item.pg.snapshot.per_day }}"
-#     all_for: "{{ item.pg.snapshot.all_for }}"
-#     fa_url: "{{ purefa_url }}"
-#     api_token: "{{ purefa_api_token }}"
-#   when:
-#   - item.pg is defined
-#   - item.pg.snapshot is defined
+- name: Update protection group snapshot schedule
+  purestorage.flasharray.purefa_pgsched:
+    name: "{{ item.pg.name | default(item.name) }}"
+    schedule: snapshot
+    enabled: "{{ item.pg.snapshot.enabled | default('true')}}"
+    state: "{{ item.pg.snapshot.state | default('present')}}"
+    snap_frequency: "{{ item.pg.snapshot.frequency | default('3600') }}" # 1h
+    snap_at: "{{ item.pg.snapshot.at | default(omit) }}"
+    per_day: "{{ item.pg.snapshot.per_day | default('1')  }}" # 1day
+    days: "{{ item.pg.snapshot.for_days | default('7')  }}" # 7days
+    all_for: "{{ item.pg.snapshot.retain_for | default('86400')  }}" # 1day
+    fa_url: "{{ purefa_url }}"
+    api_token: "{{ purefa_api_token }}"
+  when:
+  - item.pg is defined
+  - item.pg.snapshot is defined


### PR DESCRIPTION
# What is in this PR
We add support to :
* replication connections
* volume groups 
* volumes
* hosts groups
* hosts
* protection groups and its:
    * snapshot schedule (release 1.1.9)
    * replication schedule (release 1.1.9)

PS: schedules will only work after this [PR](https://github.com/Pure-Storage-Ansible/FlashArray-Collection/pull/42) is merged and a new release is available.

# How was it tested
The `gm-flasharray01` was used to test the changes.