### PR TITLE
Remove temporary code to handle pre-5.2 Purity OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Pure FlashArray
 ===============
 
+Requires Purity 5.2+
+
 Configure Pure FlashArray.
 
 To download the role you can use `ansible-galaxy`. For that create a file `requirements.yml` with the following content:
@@ -12,7 +14,7 @@ To download the role you can use `ansible-galaxy`. For that create a file `requi
   name: powerhome.purefa
 ```
 
-Afte that run the command:
+After that run the command:
 ```
 ansible-galaxy install -r requirements.yml
 ```

--- a/tasks/directory_service.yml
+++ b/tasks/directory_service.yml
@@ -1,23 +1,8 @@
 ---
-- name: directory service pre-5.2.0
-  purestorage.flasharray.purefa_ds:
-    enable: "{{ purefa_ldap.enable }}"
-    uri: "{{ purefa_ldap.uri }}"
-    base_dn: "{{ purefa_ldap.base_dn }}"
-    bind_user: "{{ purefa_ldap.bind_user }}"
-    bind_password: "{{ purefa_ldap_bind_password }}"
-    group_base: "{{ purefa_ldap.group_base }}"
-    state: "{{ purefa_ldap.state | default('present')}}"
-    aa_group: "{{ purefa_ldap.aa_group | default(omit)}}"
-    sa_group: "{{ purefa_ldap.sa_group | default(omit)}}"
-    ro_group: "{{ purefa_ldap.sa_group | default(omit)}}"
-    fa_url: "{{ purefa_url }}"
-    api_token: "{{ purefa_api_token }}"
-  when: array_info.purefa_info.default.purity_version < '5.2.0'
 
-- name: directory service 5.2.0 or higher
+- name: directory service
   block:
-  - name: Manage directory 5.2.0 or higher
+  - name: Manage directory
     purestorage.flasharray.purefa_ds:
       enable: "{{ purefa_ldap.enable }}"
       uri: "{{ purefa_ldap.uri }}"
@@ -29,7 +14,7 @@
       fa_url: "{{ purefa_url }}"
       api_token: "{{ purefa_api_token }}"
 
-  - name: Manage array admin role 5.2.0 or higher
+  - name: Manage array admin role
     purestorage.flasharray.purefa_dsrole:
       role: array_admin
       group_base: "{{ purefa_ldap.group_base if purefa_ldap.aa_group is defined else omit }}"
@@ -38,7 +23,7 @@
       fa_url: "{{ purefa_url }}"
       api_token: "{{ purefa_api_token }}"
 
-  - name: Manage storage admin role 5.2.0 or higher
+  - name: Manage storage admin role
     purestorage.flasharray.purefa_dsrole:
       role: storage_admin
       group_base: "{{ purefa_ldap.group_base if purefa_ldap.sa_group is defined else omit }}"
@@ -47,7 +32,7 @@
       fa_url: "{{ purefa_url }}"
       api_token: "{{ purefa_api_token }}"
 
-  - name: Manage ops admin role 5.2.0 or higher
+  - name: Manage ops admin role
     purestorage.flasharray.purefa_dsrole:
       role: ops_admin
       group_base: "{{ purefa_ldap.group_base if purefa_ldap.oa_group is defined else omit }}"
@@ -56,7 +41,7 @@
       fa_url: "{{ purefa_url }}"
       api_token: "{{ purefa_api_token }}"
 
-  - name: Manage readonly role 5.2.0 or higher
+  - name: Manage readonly role
     purestorage.flasharray.purefa_dsrole:
       role: readonly
       group_base: "{{ purefa_ldap.group_base if purefa_ldap.ro_group is defined else omit }}"
@@ -64,4 +49,3 @@
       state: "{{ 'present' if purefa_ldap.ro_group is defined else 'absent' }}"
       fa_url: "{{ purefa_url }}"
       api_token: "{{ purefa_api_token }}"
-  when: array_info.purefa_info.default.purity_version >= '5.2.0'


### PR DESCRIPTION
This code was only here temporarily until we could update the arrays. They are both running 5.3.3, so well past the version this is needed. 